### PR TITLE
Task 1.8

### DIFF
--- a/contributor/app/src/main/java/edu/upenn/cis573/project/DataManager.java
+++ b/contributor/app/src/main/java/edu/upenn/cis573/project/DataManager.java
@@ -1,7 +1,9 @@
 package edu.upenn.cis573.project;
 
+import android.icu.text.SimpleDateFormat;
 import android.util.Log;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -57,10 +59,18 @@ public class DataManager {
                     JSONObject jsonDonation = donations.getJSONObject(i);
 
                     String fund = getFundName((String)jsonDonation.get("fund"));
-                    String date = (String)jsonDonation.get("date");
+
+                    DateParser dateParserObj = new DateParser(
+                            "yyyy-MM-dd'T'HH:mm:ss",
+                            "MM/dd/yyyy"
+                    );
+                    String dateInNewFormat = dateParserObj.convertDateToNewFormat(
+                            (String) jsonDonation.get("date")
+                    );
+
                     long amount = (Integer)jsonDonation.get("amount");
 
-                    Donation donation = new Donation(fund, name, amount, date);
+                    Donation donation = new Donation(fund, name, amount, dateInNewFormat);
                     donationList.add(donation);
 
                 }
@@ -96,8 +106,7 @@ public class DataManager {
             String status = (String)json.get("status");
 
             if (status.equals("success")) {
-                String name = (String)json.get("data");
-                return name;
+                return (String)json.get("data");
             }
             else return "Unknown Fund";
 

--- a/contributor/app/src/main/java/edu/upenn/cis573/project/DateParser.java
+++ b/contributor/app/src/main/java/edu/upenn/cis573/project/DateParser.java
@@ -1,0 +1,22 @@
+package edu.upenn.cis573.project;
+
+import android.icu.text.SimpleDateFormat;
+
+import java.text.ParseException;
+import java.util.Date;
+
+public class DateParser {
+
+    private final SimpleDateFormat oldDateFormatter;
+    private final SimpleDateFormat newDateFormatter;
+
+    public DateParser(String oldFormat, String newFormat){
+        this.oldDateFormatter = new SimpleDateFormat(oldFormat);
+        this.newDateFormatter = new SimpleDateFormat(newFormat);
+    }
+
+    public String convertDateToNewFormat(String dateInOldFormat) throws ParseException {
+        Date date = oldDateFormatter.parse(dateInOldFormat);
+        return newDateFormatter.format(date);
+    }
+}

--- a/org/README.md
+++ b/org/README.md
@@ -1,1 +1,4 @@
 # cis573-project-org
+
+## Changes Made
+* Task 1.8: To complete this task, the project utilizes Android's built-in class called `SimpleDateFormat` to parse the original format and to convert it into human-readable format. In detail, a new class called `DateParser` is created in the Contributor app in order to handle the conversion. The class has two new parameters, `oldDateFormat` (the date format originallly used in this project: `yyyy-MM-dd T HH:mm:ss Z`) and `newDateFormat` (the format is `MM/dd/yyyy`). And the class has a method `convertDateToNewFormat` that parses the date time in original format and converts to the new date format. The method throws `ParseException` if the parameter passed is not in the old format.


### PR DESCRIPTION
Modified Contributor's app such that it displays the date of contribution in the following format: Month/Day/Year

Task 1.8. Date formatting
Modify either the Contributor App or the Organization App so that, when listing donations, the dates are displayed like “June 18, 2021” or similar, and not the default “2021-06-18T04:21:04.807Z”. You are welcome to use a date format that makes sense to you (within reason), but should not change the RESTful API or database implementation for this, but rather should modify the Java code in the app. Note that you will only get credit for implementing date formatting in either the Contributor App or Organization App, and will not get additional credit for implementing it in both; please be sure to indicate which one you would like graded in your Writeup for this phase.