### PR TITLE
Task 1.8 (Hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 Project setup guide can be found [here](https://docs.google.com/document/d/1ERV79t_5kH_c4x5rCqEHbUp5VATvQM1lBiFNzqSf0wA/edit).
 
 Project Phase 0 Writeup can be found [here](https://docs.google.com/document/d/17hkYnv1S82FEYruonaooUfmTm8qw4XGIjdKNCce_4to/edit).
+
+## Changes Made
+* Task 1.8: To complete this task, the project utilizes Android's built-in class called `SimpleDateFormat` to parse the original format and to convert it into human-readable format. In detail, a new class called `DateParser` is created in the Contributor app in order to handle the conversion. The class has two new parameters, `oldDateFormat` (the date format originallly used in this project: `yyyy-MM-dd T HH:mm:ss Z`) and `newDateFormat` (the format is `MM/dd/yyyy`). And the class has a method `convertDateToNewFormat` that parses the date time in original format and converts to the new date format. The method throws `ParseException` if the parameter passed is not in the old format.

--- a/contributor/app/src/main/java/edu/upenn/cis573/project/MakeDonationActivity.java
+++ b/contributor/app/src/main/java/edu/upenn/cis573/project/MakeDonationActivity.java
@@ -14,6 +14,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import java.text.ParseException;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -125,7 +126,7 @@ public class MakeDonationActivity extends AppCompatActivity {
     }
 
 
-    public void onMakeDonationButtonClick(View view) {
+    public void onMakeDonationButtonClick(View view) throws ParseException {
 
         String orgId = selectedOrg.getId();
         String fundId = selectedFund.getId();
@@ -146,7 +147,10 @@ public class MakeDonationActivity extends AppCompatActivity {
 
         if (success) {
             Toast.makeText(this, "Thank you for your donation!", Toast.LENGTH_LONG).show();
-            contributor.getDonations().add(new Donation(selectedFund.getName(), contributor.getName(), Long.parseLong(amount), new Date().toString()));
+            String dateNow = new Date().toString();
+            DateParser dateParserObj = new DateParser("EEE MMM dd HH:mm:ss zzz yyyy", "MM/dd/yyyy");
+            String dateInNewFormat = dateParserObj.convertDateToNewFormat(dateNow);
+            contributor.getDonations().add(new Donation(selectedFund.getName(), contributor.getName(), Long.parseLong(amount), dateInNewFormat));
 
             new AsyncTask<String, String, String>() {
 

--- a/org/README.md
+++ b/org/README.md
@@ -1,4 +1,1 @@
 # cis573-project-org
-
-## Changes Made
-* Task 1.8: To complete this task, the project utilizes Android's built-in class called `SimpleDateFormat` to parse the original format and to convert it into human-readable format. In detail, a new class called `DateParser` is created in the Contributor app in order to handle the conversion. The class has two new parameters, `oldDateFormat` (the date format originallly used in this project: `yyyy-MM-dd T HH:mm:ss Z`) and `newDateFormat` (the format is `MM/dd/yyyy`). And the class has a method `convertDateToNewFormat` that parses the date time in original format and converts to the new date format. The method throws `ParseException` if the parameter passed is not in the old format.


### PR DESCRIPTION
The fix contains displaying the date in the format of `MM/dd/yyyy` after a contributor finishes making a new donation.
Also, the writeup for this task was placed from `/org/README.md` to `README.md` in the root directory of the project.